### PR TITLE
Add real course descriptions and per-course teaching pages

### DIFF
--- a/pages/teaching.html
+++ b/pages/teaching.html
@@ -48,22 +48,15 @@
         <h2>Web Programming I</h2>
 
         <p>
-            Brief course description. Replace this text with a summary of the
-            course objectives, topics, technologies, and learning outcomes.
+            An introductory course on front-end web development, covering
+            HTML5 markup, CSS fundamentals (selectors, the box model, and
+            layout), and the basics of structuring and styling static web
+            pages.
         </p>
 
-        <div class="course-item">
-
-            <h3>Course Offerings</h3>
-
-            <ul>
-                <li><a href="#">2026.1</a></li>
-                <li><a href="#">2025.2</a></li>
-                <li><a href="#">2025.1</a></li>
-                <li><a href="#">2024.2</a></li>
-            </ul>
-
-        </div>
+        <p>
+            <a href="teaching/web-programming-1.html">Course page →</a>
+        </p>
 
     </section>
 
@@ -72,21 +65,16 @@
         <h2>Web Programming II</h2>
 
         <p>
-            Brief course description. Replace this text with a summary of the
-            course objectives, technologies, frameworks, and practical projects.
+            A follow-up course focused on server-side web development with
+            Node.js and Express, covering MVC architecture, server-side
+            templating with EJS, building CRUD applications, and an
+            introduction to common web security vulnerabilities such as SQL
+            injection and session management.
         </p>
 
-        <div class="course-item">
-
-            <h3>Course Offerings</h3>
-
-            <ul>
-                <li><a href="#">2026.1</a></li>
-                <li><a href="#">2025.2</a></li>
-                <li><a href="#">2025.1</a></li>
-            </ul>
-
-        </div>
+        <p>
+            <a href="teaching/web-programming-2.html">Course page →</a>
+        </p>
 
     </section>
 
@@ -95,22 +83,16 @@
         <h2>Programming Languages</h2>
 
         <p>
-            Brief course description. Replace this text with a summary covering
-            programming paradigms, language design, formal grammars,
-            semantics, subprograms, type systems, and related topics.
+            A course on programming paradigms and language design, with a
+            focus on object-oriented programming in Java: classes and
+            objects, exception handling, and the design of multi-class
+            systems, alongside core concepts of language semantics and
+            subprograms.
         </p>
 
-        <div class="course-item">
-
-            <h3>Course Offerings</h3>
-
-            <ul>
-                <li><a href="#">2026.1</a></li>
-                <li><a href="#">2025.2</a></li>
-                <li><a href="#">2024.2</a></li>
-            </ul>
-
-        </div>
+        <p>
+            <a href="teaching/programming-languages.html">Course page →</a>
+        </p>
 
     </section>
 

--- a/pages/teaching/programming-languages.html
+++ b/pages/teaching/programming-languages.html
@@ -1,0 +1,87 @@
+<!DOCTYPE HTML>
+<html lang="en-US">
+
+<head>
+
+    <meta charset="UTF-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1"/>
+
+    <title>Programming Languages — Leo Fernandes</title>
+
+    <meta http-equiv="content-language" content="en-us">
+
+    <link rel="preload"
+          href="../../assets/fonts/Grand-Regular-2022-01-30.woff2"
+          as="font"
+          type="font/woff2"
+          crossorigin>
+
+    <link rel="preload"
+          href="../../assets/fonts/Grand-Medium-2022-01-30.woff2"
+          as="font"
+          type="font/woff2"
+          crossorigin>
+
+    <link rel="stylesheet"
+          href="../../assets/css/style.css">
+
+</head>
+
+<body>
+
+<footer>
+
+    <section>
+
+        <h1>Programming Languages</h1>
+
+        <p>
+            A course on programming paradigms and language design, with a
+            focus on object-oriented programming in Java: classes and
+            objects, exception handling, and the design of multi-class
+            systems, alongside core concepts of language semantics and
+            subprograms.
+        </p>
+
+    </section>
+
+    <section>
+
+        <h2>Course Materials</h2>
+
+        <p>
+            Slides, exercises, and code examples specific to this course
+            will be listed here.
+        </p>
+
+    </section>
+
+    <section>
+
+        <h2>Offerings</h2>
+
+        <div class="course-item">
+
+            <ul>
+                <!-- Add one entry per year/semester, e.g.:
+                <li><a href="#">2026.1</a></li>
+                -->
+            </ul>
+
+        </div>
+
+    </section>
+
+    <section>
+
+        <p>
+            <a href="../teaching.html">← Teaching</a>
+        </p>
+
+    </section>
+
+</footer>
+
+</body>
+
+</html>

--- a/pages/teaching/web-programming-1.html
+++ b/pages/teaching/web-programming-1.html
@@ -1,0 +1,86 @@
+<!DOCTYPE HTML>
+<html lang="en-US">
+
+<head>
+
+    <meta charset="UTF-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1"/>
+
+    <title>Web Programming I — Leo Fernandes</title>
+
+    <meta http-equiv="content-language" content="en-us">
+
+    <link rel="preload"
+          href="../../assets/fonts/Grand-Regular-2022-01-30.woff2"
+          as="font"
+          type="font/woff2"
+          crossorigin>
+
+    <link rel="preload"
+          href="../../assets/fonts/Grand-Medium-2022-01-30.woff2"
+          as="font"
+          type="font/woff2"
+          crossorigin>
+
+    <link rel="stylesheet"
+          href="../../assets/css/style.css">
+
+</head>
+
+<body>
+
+<footer>
+
+    <section>
+
+        <h1>Web Programming I</h1>
+
+        <p>
+            An introductory course on front-end web development, covering
+            HTML5 markup, CSS fundamentals (selectors, the box model, and
+            layout), and the basics of structuring and styling static web
+            pages.
+        </p>
+
+    </section>
+
+    <section>
+
+        <h2>Course Materials</h2>
+
+        <p>
+            Slides, exercises, and code examples specific to this course
+            will be listed here.
+        </p>
+
+    </section>
+
+    <section>
+
+        <h2>Offerings</h2>
+
+        <div class="course-item">
+
+            <ul>
+                <!-- Add one entry per year/semester, e.g.:
+                <li><a href="#">2026.1</a></li>
+                -->
+            </ul>
+
+        </div>
+
+    </section>
+
+    <section>
+
+        <p>
+            <a href="../teaching.html">← Teaching</a>
+        </p>
+
+    </section>
+
+</footer>
+
+</body>
+
+</html>

--- a/pages/teaching/web-programming-2.html
+++ b/pages/teaching/web-programming-2.html
@@ -1,0 +1,87 @@
+<!DOCTYPE HTML>
+<html lang="en-US">
+
+<head>
+
+    <meta charset="UTF-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1"/>
+
+    <title>Web Programming II — Leo Fernandes</title>
+
+    <meta http-equiv="content-language" content="en-us">
+
+    <link rel="preload"
+          href="../../assets/fonts/Grand-Regular-2022-01-30.woff2"
+          as="font"
+          type="font/woff2"
+          crossorigin>
+
+    <link rel="preload"
+          href="../../assets/fonts/Grand-Medium-2022-01-30.woff2"
+          as="font"
+          type="font/woff2"
+          crossorigin>
+
+    <link rel="stylesheet"
+          href="../../assets/css/style.css">
+
+</head>
+
+<body>
+
+<footer>
+
+    <section>
+
+        <h1>Web Programming II</h1>
+
+        <p>
+            A follow-up course focused on server-side web development with
+            Node.js and Express, covering MVC architecture, server-side
+            templating with EJS, building CRUD applications, and an
+            introduction to common web security vulnerabilities such as SQL
+            injection and session management.
+        </p>
+
+    </section>
+
+    <section>
+
+        <h2>Course Materials</h2>
+
+        <p>
+            Slides, exercises, and code examples specific to this course
+            will be listed here.
+        </p>
+
+    </section>
+
+    <section>
+
+        <h2>Offerings</h2>
+
+        <div class="course-item">
+
+            <ul>
+                <!-- Add one entry per year/semester, e.g.:
+                <li><a href="#">2026.1</a></li>
+                -->
+            </ul>
+
+        </div>
+
+    </section>
+
+    <section>
+
+        <p>
+            <a href="../teaching.html">← Teaching</a>
+        </p>
+
+    </section>
+
+</footer>
+
+</body>
+
+</html>


### PR DESCRIPTION
## Summary
- Replace placeholder text in the Teaching page with real descriptions for Web Programming I, Web Programming II, and Programming Languages, based on actual course materials.
- Remove the year/semester offering lists from the main Teaching page.
- Add a dedicated page per course under `pages/teaching/` (`web-programming-1.html`, `web-programming-2.html`, `programming-languages.html`) with placeholders for course materials and offering links, so year/semester content can be added per course going forward.

## Test plan
- [x] Served the site locally and clicked through `pages/teaching.html` → each "Course page →" link → "← Teaching" back link.
- [x] Checked network requests for all three new pages — no failed asset loads (CSS/fonts resolve correctly via `../../assets/...`).