### PR TITLE
Add syllabus sections to each course page

### DIFF
--- a/pages/teaching/programming-languages.html
+++ b/pages/teaching/programming-languages.html
@@ -36,22 +36,109 @@
         <h1>Programming Languages</h1>
 
         <p>
-            A course on programming paradigms and language design, with a
-            focus on object-oriented programming in Java: classes and
-            objects, exception handling, and the design of multi-class
-            systems, alongside core concepts of language semantics and
-            subprograms.
+            <em>The content on this page is written in Brazilian Portuguese
+            (pt-BR), as it is intended for students enrolled in this
+            course.</em>
         </p>
 
     </section>
 
-    <section>
+    <section lang="pt-BR">
 
-        <h2>Course Materials</h2>
+        <h2>Descrição da disciplina</h2>
 
         <p>
-            Slides, exercises, and code examples specific to this course
-            will be listed here.
+            Curso sobre paradigmas de programação e design de linguagens,
+            com foco em programação orientada a objetos em Java: classes e
+            objetos, tratamento de exceções e o design de sistemas com
+            múltiplas classes, além de conceitos centrais de semântica de
+            linguagens e subprogramas.
+        </p>
+
+    </section>
+
+    <section lang="pt-BR">
+
+        <h2>Horários das aulas</h2>
+
+        <p>
+            Os horários específicos desta oferta serão informados aqui.
+        </p>
+
+    </section>
+
+    <section lang="pt-BR">
+
+        <h2>Equipe</h2>
+
+        <p>
+            Docentes, monitores e equipe de apoio desta disciplina serão
+            listados aqui.
+        </p>
+
+    </section>
+
+    <section lang="pt-BR">
+
+        <h2>Calendário do semestre</h2>
+
+        <p>
+            O calendário com aulas, avaliações e entregas será publicado
+            aqui a cada semestre.
+        </p>
+
+    </section>
+
+    <section lang="pt-BR">
+
+        <h2>Pré-requisitos</h2>
+
+        <p>
+            Os pré-requisitos desta disciplina serão informados aqui.
+        </p>
+
+    </section>
+
+    <section lang="pt-BR">
+
+        <h2>Material de leitura</h2>
+
+        <p>
+            Bibliografia, slides e materiais de leitura complementares
+            serão listados aqui.
+        </p>
+
+    </section>
+
+    <section lang="pt-BR">
+
+        <h2>Horário de atendimento</h2>
+
+        <p>
+            O horário de atendimento (plantão de dúvidas) será informado
+            aqui.
+        </p>
+
+    </section>
+
+    <section lang="pt-BR">
+
+        <h2>Política de colaboração</h2>
+
+        <p>
+            As regras sobre trabalho em grupo, uso de IA e o que é
+            considerado plágio serão detalhadas aqui.
+        </p>
+
+    </section>
+
+    <section lang="pt-BR">
+
+        <h2>Orientações para os trabalhos, provas e notas</h2>
+
+        <p>
+            Os critérios de avaliação, pesos, formato das provas e a
+            política de notas serão detalhados aqui.
         </p>
 
     </section>

--- a/pages/teaching/web-programming-1.html
+++ b/pages/teaching/web-programming-1.html
@@ -36,21 +36,108 @@
         <h1>Web Programming I</h1>
 
         <p>
-            An introductory course on front-end web development, covering
-            HTML5 markup, CSS fundamentals (selectors, the box model, and
-            layout), and the basics of structuring and styling static web
-            pages.
+            <em>The content on this page is written in Brazilian Portuguese
+            (pt-BR), as it is intended for students enrolled in this
+            course.</em>
         </p>
 
     </section>
 
-    <section>
+    <section lang="pt-BR">
 
-        <h2>Course Materials</h2>
+        <h2>Descrição da disciplina</h2>
 
         <p>
-            Slides, exercises, and code examples specific to this course
-            will be listed here.
+            Curso introdutório de desenvolvimento web front-end, cobrindo
+            marcação HTML5, fundamentos de CSS (seletores, box model e
+            layout) e os princípios básicos de estruturação e estilização
+            de páginas web estáticas.
+        </p>
+
+    </section>
+
+    <section lang="pt-BR">
+
+        <h2>Horários das aulas</h2>
+
+        <p>
+            Os horários específicos desta oferta serão informados aqui.
+        </p>
+
+    </section>
+
+    <section lang="pt-BR">
+
+        <h2>Equipe</h2>
+
+        <p>
+            Docentes, monitores e equipe de apoio desta disciplina serão
+            listados aqui.
+        </p>
+
+    </section>
+
+    <section lang="pt-BR">
+
+        <h2>Calendário do semestre</h2>
+
+        <p>
+            O calendário com aulas, avaliações e entregas será publicado
+            aqui a cada semestre.
+        </p>
+
+    </section>
+
+    <section lang="pt-BR">
+
+        <h2>Pré-requisitos</h2>
+
+        <p>
+            Os pré-requisitos desta disciplina serão informados aqui.
+        </p>
+
+    </section>
+
+    <section lang="pt-BR">
+
+        <h2>Material de leitura</h2>
+
+        <p>
+            Bibliografia, slides e materiais de leitura complementares
+            serão listados aqui.
+        </p>
+
+    </section>
+
+    <section lang="pt-BR">
+
+        <h2>Horário de atendimento</h2>
+
+        <p>
+            O horário de atendimento (plantão de dúvidas) será informado
+            aqui.
+        </p>
+
+    </section>
+
+    <section lang="pt-BR">
+
+        <h2>Política de colaboração</h2>
+
+        <p>
+            As regras sobre trabalho em grupo, uso de IA e o que é
+            considerado plágio serão detalhadas aqui.
+        </p>
+
+    </section>
+
+    <section lang="pt-BR">
+
+        <h2>Orientações para os trabalhos, provas e notas</h2>
+
+        <p>
+            Os critérios de avaliação, pesos, formato das provas e a
+            política de notas serão detalhados aqui.
         </p>
 
     </section>

--- a/pages/teaching/web-programming-2.html
+++ b/pages/teaching/web-programming-2.html
@@ -36,22 +36,109 @@
         <h1>Web Programming II</h1>
 
         <p>
-            A follow-up course focused on server-side web development with
-            Node.js and Express, covering MVC architecture, server-side
-            templating with EJS, building CRUD applications, and an
-            introduction to common web security vulnerabilities such as SQL
-            injection and session management.
+            <em>The content on this page is written in Brazilian Portuguese
+            (pt-BR), as it is intended for students enrolled in this
+            course.</em>
         </p>
 
     </section>
 
-    <section>
+    <section lang="pt-BR">
 
-        <h2>Course Materials</h2>
+        <h2>Descrição da disciplina</h2>
 
         <p>
-            Slides, exercises, and code examples specific to this course
-            will be listed here.
+            Curso de continuidade focado em desenvolvimento web no lado do
+            servidor com Node.js e Express, cobrindo arquitetura MVC,
+            templating no servidor com EJS, construção de aplicações CRUD
+            e uma introdução a vulnerabilidades comuns de segurança web,
+            como injeção de SQL e gerenciamento de sessões.
+        </p>
+
+    </section>
+
+    <section lang="pt-BR">
+
+        <h2>Horários das aulas</h2>
+
+        <p>
+            Os horários específicos desta oferta serão informados aqui.
+        </p>
+
+    </section>
+
+    <section lang="pt-BR">
+
+        <h2>Equipe</h2>
+
+        <p>
+            Docentes, monitores e equipe de apoio desta disciplina serão
+            listados aqui.
+        </p>
+
+    </section>
+
+    <section lang="pt-BR">
+
+        <h2>Calendário do semestre</h2>
+
+        <p>
+            O calendário com aulas, avaliações e entregas será publicado
+            aqui a cada semestre.
+        </p>
+
+    </section>
+
+    <section lang="pt-BR">
+
+        <h2>Pré-requisitos</h2>
+
+        <p>
+            Os pré-requisitos desta disciplina serão informados aqui.
+        </p>
+
+    </section>
+
+    <section lang="pt-BR">
+
+        <h2>Material de leitura</h2>
+
+        <p>
+            Bibliografia, slides e materiais de leitura complementares
+            serão listados aqui.
+        </p>
+
+    </section>
+
+    <section lang="pt-BR">
+
+        <h2>Horário de atendimento</h2>
+
+        <p>
+            O horário de atendimento (plantão de dúvidas) será informado
+            aqui.
+        </p>
+
+    </section>
+
+    <section lang="pt-BR">
+
+        <h2>Política de colaboração</h2>
+
+        <p>
+            As regras sobre trabalho em grupo, uso de IA e o que é
+            considerado plágio serão detalhadas aqui.
+        </p>
+
+    </section>
+
+    <section lang="pt-BR">
+
+        <h2>Orientações para os trabalhos, provas e notas</h2>
+
+        <p>
+            Os critérios de avaliação, pesos, formato das provas e a
+            política de notas serão detalhados aqui.
         </p>
 
     </section>


### PR DESCRIPTION
Add a pt-BR content notice and syllabus-style sections (description, schedule, team, calendar, prerequisites, reading material, office hours, collaboration policy, and grading guidelines) to each of the three teaching pages, so course-specific details can be filled in per section going forward.