### PR TITLE
Turn course-page sections into accordions

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -566,3 +566,87 @@ footer a:active  { color: #d47800; border-bottom: 1px dotted #d47800; }
 
     color: #005C2E;
 }
+
+/* ==================================================
+   Accordion
+   ================================================== */
+
+.accordion {
+    border: 1px solid var(--border);
+    border-radius: 0.75rem;
+    background: #F8FBF8;
+    overflow: hidden;
+    transition: border-color 0.2s ease;
+}
+
+.accordion + .accordion {
+    margin-top: 1rem;
+}
+
+.accordion:hover {
+    border-color: var(--ifal-green-light);
+}
+
+.accordion-summary {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    list-style: none;
+    cursor: pointer;
+    padding: 1.25rem 1.5rem;
+    user-select: none;
+}
+
+.accordion-summary::-webkit-details-marker {
+    display: none;
+}
+
+.accordion-summary::marker {
+    content: "";
+}
+
+.accordion-summary h2 {
+    font-size: 1.6rem;
+    margin-bottom: 0;
+    transition: color 0.2s ease;
+}
+
+.accordion-summary:hover h2 {
+    color: var(--ifal-green-dark);
+}
+
+.accordion-icon {
+    flex-shrink: 0;
+    width: 1.4rem;
+    height: 1.4rem;
+    color: var(--ifal-green);
+    transition: transform 0.2s ease;
+}
+
+.accordion[open] .accordion-icon {
+    transform: rotate(180deg);
+}
+
+.accordion-panel {
+    padding: 0 1.5rem 1.5rem;
+}
+
+.accordion-panel p:first-child {
+    margin-top: 0;
+}
+
+.accordion-panel p:last-child {
+    margin-bottom: 0;
+}
+
+@starting-style {
+    .accordion[open] .accordion-panel {
+        opacity: 0;
+    }
+}
+
+.accordion[open] .accordion-panel {
+    opacity: 1;
+    transition: opacity 0.25s ease;
+}

--- a/pages/teaching/programming-languages.html
+++ b/pages/teaching/programming-languages.html
@@ -43,119 +43,223 @@
 
     </section>
 
-    <section lang="pt-BR">
-
-        <h2>Descrição da disciplina</h2>
-
-        <p>
-            Curso sobre paradigmas de programação e design de linguagens,
-            com foco em programação orientada a objetos em Java: classes e
-            objetos, tratamento de exceções e o design de sistemas com
-            múltiplas classes, além de conceitos centrais de semântica de
-            linguagens e subprogramas.
-        </p>
-
-    </section>
-
-    <section lang="pt-BR">
-
-        <h2>Horários das aulas</h2>
-
-        <p>
-            Os horários específicos desta oferta serão informados aqui.
-        </p>
-
-    </section>
-
-    <section lang="pt-BR">
-
-        <h2>Equipe</h2>
-
-        <p>
-            Docentes, monitores e equipe de apoio desta disciplina serão
-            listados aqui.
-        </p>
-
-    </section>
-
-    <section lang="pt-BR">
-
-        <h2>Calendário do semestre</h2>
-
-        <p>
-            O calendário com aulas, avaliações e entregas será publicado
-            aqui a cada semestre.
-        </p>
-
-    </section>
-
-    <section lang="pt-BR">
-
-        <h2>Pré-requisitos</h2>
-
-        <p>
-            Os pré-requisitos desta disciplina serão informados aqui.
-        </p>
-
-    </section>
-
-    <section lang="pt-BR">
-
-        <h2>Material de leitura</h2>
-
-        <p>
-            Bibliografia, slides e materiais de leitura complementares
-            serão listados aqui.
-        </p>
-
-    </section>
-
-    <section lang="pt-BR">
-
-        <h2>Horário de atendimento</h2>
-
-        <p>
-            O horário de atendimento (plantão de dúvidas) será informado
-            aqui.
-        </p>
-
-    </section>
-
-    <section lang="pt-BR">
-
-        <h2>Política de colaboração</h2>
-
-        <p>
-            As regras sobre trabalho em grupo, uso de IA e o que é
-            considerado plágio serão detalhadas aqui.
-        </p>
-
-    </section>
-
-    <section lang="pt-BR">
-
-        <h2>Orientações para os trabalhos, provas e notas</h2>
-
-        <p>
-            Os critérios de avaliação, pesos, formato das provas e a
-            política de notas serão detalhados aqui.
-        </p>
-
-    </section>
-
     <section>
 
-        <h2>Offerings</h2>
+        <details class="accordion" name="course-accordion" lang="pt-BR">
 
-        <div class="course-item">
+            <summary class="accordion-summary">
+                <h2>Descrição da disciplina</h2>
+                <svg class="accordion-icon" viewBox="0 0 24 24" aria-hidden="true">
+                    <path d="M6 9l6 6 6-6" fill="none" stroke="currentColor"
+                          stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                </svg>
+            </summary>
 
-            <ul>
-                <!-- Add one entry per year/semester, e.g.:
-                <li><a href="#">2026.1</a></li>
-                -->
-            </ul>
+            <div class="accordion-panel">
 
-        </div>
+                <p>
+                    Curso sobre paradigmas de programação e design de linguagens,
+                    com foco em programação orientada a objetos em Java: classes e
+                    objetos, tratamento de exceções e o design de sistemas com
+                    múltiplas classes, além de conceitos centrais de semântica de
+                    linguagens e subprogramas.
+                </p>
+
+            </div>
+
+        </details>
+
+        <details class="accordion" name="course-accordion" lang="pt-BR">
+
+            <summary class="accordion-summary">
+                <h2>Horários das aulas</h2>
+                <svg class="accordion-icon" viewBox="0 0 24 24" aria-hidden="true">
+                    <path d="M6 9l6 6 6-6" fill="none" stroke="currentColor"
+                          stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                </svg>
+            </summary>
+
+            <div class="accordion-panel">
+
+                <p>
+                    Os horários específicos desta oferta serão informados aqui.
+                </p>
+
+            </div>
+
+        </details>
+
+        <details class="accordion" name="course-accordion" lang="pt-BR">
+
+            <summary class="accordion-summary">
+                <h2>Equipe</h2>
+                <svg class="accordion-icon" viewBox="0 0 24 24" aria-hidden="true">
+                    <path d="M6 9l6 6 6-6" fill="none" stroke="currentColor"
+                          stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                </svg>
+            </summary>
+
+            <div class="accordion-panel">
+
+                <p>
+                    Docentes, monitores e equipe de apoio desta disciplina serão
+                    listados aqui.
+                </p>
+
+            </div>
+
+        </details>
+
+        <details class="accordion" name="course-accordion" lang="pt-BR">
+
+            <summary class="accordion-summary">
+                <h2>Calendário do semestre</h2>
+                <svg class="accordion-icon" viewBox="0 0 24 24" aria-hidden="true">
+                    <path d="M6 9l6 6 6-6" fill="none" stroke="currentColor"
+                          stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                </svg>
+            </summary>
+
+            <div class="accordion-panel">
+
+                <p>
+                    O calendário com aulas, avaliações e entregas será publicado
+                    aqui a cada semestre.
+                </p>
+
+            </div>
+
+        </details>
+
+        <details class="accordion" name="course-accordion" lang="pt-BR">
+
+            <summary class="accordion-summary">
+                <h2>Pré-requisitos</h2>
+                <svg class="accordion-icon" viewBox="0 0 24 24" aria-hidden="true">
+                    <path d="M6 9l6 6 6-6" fill="none" stroke="currentColor"
+                          stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                </svg>
+            </summary>
+
+            <div class="accordion-panel">
+
+                <p>
+                    Os pré-requisitos desta disciplina serão informados aqui.
+                </p>
+
+            </div>
+
+        </details>
+
+        <details class="accordion" name="course-accordion" lang="pt-BR">
+
+            <summary class="accordion-summary">
+                <h2>Material de leitura</h2>
+                <svg class="accordion-icon" viewBox="0 0 24 24" aria-hidden="true">
+                    <path d="M6 9l6 6 6-6" fill="none" stroke="currentColor"
+                          stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                </svg>
+            </summary>
+
+            <div class="accordion-panel">
+
+                <p>
+                    Bibliografia, slides e materiais de leitura complementares
+                    serão listados aqui.
+                </p>
+
+            </div>
+
+        </details>
+
+        <details class="accordion" name="course-accordion" lang="pt-BR">
+
+            <summary class="accordion-summary">
+                <h2>Horário de atendimento</h2>
+                <svg class="accordion-icon" viewBox="0 0 24 24" aria-hidden="true">
+                    <path d="M6 9l6 6 6-6" fill="none" stroke="currentColor"
+                          stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                </svg>
+            </summary>
+
+            <div class="accordion-panel">
+
+                <p>
+                    O horário de atendimento (plantão de dúvidas) será informado
+                    aqui.
+                </p>
+
+            </div>
+
+        </details>
+
+        <details class="accordion" name="course-accordion" lang="pt-BR">
+
+            <summary class="accordion-summary">
+                <h2>Política de colaboração</h2>
+                <svg class="accordion-icon" viewBox="0 0 24 24" aria-hidden="true">
+                    <path d="M6 9l6 6 6-6" fill="none" stroke="currentColor"
+                          stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                </svg>
+            </summary>
+
+            <div class="accordion-panel">
+
+                <p>
+                    As regras sobre trabalho em grupo, uso de IA e o que é
+                    considerado plágio serão detalhadas aqui.
+                </p>
+
+            </div>
+
+        </details>
+
+        <details class="accordion" name="course-accordion" lang="pt-BR">
+
+            <summary class="accordion-summary">
+                <h2>Orientações para os trabalhos, provas e notas</h2>
+                <svg class="accordion-icon" viewBox="0 0 24 24" aria-hidden="true">
+                    <path d="M6 9l6 6 6-6" fill="none" stroke="currentColor"
+                          stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                </svg>
+            </summary>
+
+            <div class="accordion-panel">
+
+                <p>
+                    Os critérios de avaliação, pesos, formato das provas e a
+                    política de notas serão detalhados aqui.
+                </p>
+
+            </div>
+
+        </details>
+
+        <details class="accordion" name="course-accordion">
+
+            <summary class="accordion-summary">
+                <h2>Offerings</h2>
+                <svg class="accordion-icon" viewBox="0 0 24 24" aria-hidden="true">
+                    <path d="M6 9l6 6 6-6" fill="none" stroke="currentColor"
+                          stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                </svg>
+            </summary>
+
+            <div class="accordion-panel">
+
+                <div class="course-item">
+
+                    <ul>
+                        <!-- Add one entry per year/semester, e.g.:
+                        <li><a href="#">2026.1</a></li>
+                        -->
+                    </ul>
+
+                </div>
+
+            </div>
+
+        </details>
 
     </section>
 

--- a/pages/teaching/web-programming-1.html
+++ b/pages/teaching/web-programming-1.html
@@ -43,118 +43,222 @@
 
     </section>
 
-    <section lang="pt-BR">
-
-        <h2>Descrição da disciplina</h2>
-
-        <p>
-            Curso introdutório de desenvolvimento web front-end, cobrindo
-            marcação HTML5, fundamentos de CSS (seletores, box model e
-            layout) e os princípios básicos de estruturação e estilização
-            de páginas web estáticas.
-        </p>
-
-    </section>
-
-    <section lang="pt-BR">
-
-        <h2>Horários das aulas</h2>
-
-        <p>
-            Os horários específicos desta oferta serão informados aqui.
-        </p>
-
-    </section>
-
-    <section lang="pt-BR">
-
-        <h2>Equipe</h2>
-
-        <p>
-            Docentes, monitores e equipe de apoio desta disciplina serão
-            listados aqui.
-        </p>
-
-    </section>
-
-    <section lang="pt-BR">
-
-        <h2>Calendário do semestre</h2>
-
-        <p>
-            O calendário com aulas, avaliações e entregas será publicado
-            aqui a cada semestre.
-        </p>
-
-    </section>
-
-    <section lang="pt-BR">
-
-        <h2>Pré-requisitos</h2>
-
-        <p>
-            Os pré-requisitos desta disciplina serão informados aqui.
-        </p>
-
-    </section>
-
-    <section lang="pt-BR">
-
-        <h2>Material de leitura</h2>
-
-        <p>
-            Bibliografia, slides e materiais de leitura complementares
-            serão listados aqui.
-        </p>
-
-    </section>
-
-    <section lang="pt-BR">
-
-        <h2>Horário de atendimento</h2>
-
-        <p>
-            O horário de atendimento (plantão de dúvidas) será informado
-            aqui.
-        </p>
-
-    </section>
-
-    <section lang="pt-BR">
-
-        <h2>Política de colaboração</h2>
-
-        <p>
-            As regras sobre trabalho em grupo, uso de IA e o que é
-            considerado plágio serão detalhadas aqui.
-        </p>
-
-    </section>
-
-    <section lang="pt-BR">
-
-        <h2>Orientações para os trabalhos, provas e notas</h2>
-
-        <p>
-            Os critérios de avaliação, pesos, formato das provas e a
-            política de notas serão detalhados aqui.
-        </p>
-
-    </section>
-
     <section>
 
-        <h2>Offerings</h2>
+        <details class="accordion" name="course-accordion" lang="pt-BR">
 
-        <div class="course-item">
+            <summary class="accordion-summary">
+                <h2>Descrição da disciplina</h2>
+                <svg class="accordion-icon" viewBox="0 0 24 24" aria-hidden="true">
+                    <path d="M6 9l6 6 6-6" fill="none" stroke="currentColor"
+                          stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                </svg>
+            </summary>
 
-            <ul>
-                <!-- Add one entry per year/semester, e.g.:
-                <li><a href="#">2026.1</a></li>
-                -->
-            </ul>
+            <div class="accordion-panel">
 
-        </div>
+                <p>
+                    Curso introdutório de desenvolvimento web front-end, cobrindo
+                    marcação HTML5, fundamentos de CSS (seletores, box model e
+                    layout) e os princípios básicos de estruturação e estilização
+                    de páginas web estáticas.
+                </p>
+
+            </div>
+
+        </details>
+
+        <details class="accordion" name="course-accordion" lang="pt-BR">
+
+            <summary class="accordion-summary">
+                <h2>Horários das aulas</h2>
+                <svg class="accordion-icon" viewBox="0 0 24 24" aria-hidden="true">
+                    <path d="M6 9l6 6 6-6" fill="none" stroke="currentColor"
+                          stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                </svg>
+            </summary>
+
+            <div class="accordion-panel">
+
+                <p>
+                    Os horários específicos desta oferta serão informados aqui.
+                </p>
+
+            </div>
+
+        </details>
+
+        <details class="accordion" name="course-accordion" lang="pt-BR">
+
+            <summary class="accordion-summary">
+                <h2>Equipe</h2>
+                <svg class="accordion-icon" viewBox="0 0 24 24" aria-hidden="true">
+                    <path d="M6 9l6 6 6-6" fill="none" stroke="currentColor"
+                          stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                </svg>
+            </summary>
+
+            <div class="accordion-panel">
+
+                <p>
+                    Docentes, monitores e equipe de apoio desta disciplina serão
+                    listados aqui.
+                </p>
+
+            </div>
+
+        </details>
+
+        <details class="accordion" name="course-accordion" lang="pt-BR">
+
+            <summary class="accordion-summary">
+                <h2>Calendário do semestre</h2>
+                <svg class="accordion-icon" viewBox="0 0 24 24" aria-hidden="true">
+                    <path d="M6 9l6 6 6-6" fill="none" stroke="currentColor"
+                          stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                </svg>
+            </summary>
+
+            <div class="accordion-panel">
+
+                <p>
+                    O calendário com aulas, avaliações e entregas será publicado
+                    aqui a cada semestre.
+                </p>
+
+            </div>
+
+        </details>
+
+        <details class="accordion" name="course-accordion" lang="pt-BR">
+
+            <summary class="accordion-summary">
+                <h2>Pré-requisitos</h2>
+                <svg class="accordion-icon" viewBox="0 0 24 24" aria-hidden="true">
+                    <path d="M6 9l6 6 6-6" fill="none" stroke="currentColor"
+                          stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                </svg>
+            </summary>
+
+            <div class="accordion-panel">
+
+                <p>
+                    Os pré-requisitos desta disciplina serão informados aqui.
+                </p>
+
+            </div>
+
+        </details>
+
+        <details class="accordion" name="course-accordion" lang="pt-BR">
+
+            <summary class="accordion-summary">
+                <h2>Material de leitura</h2>
+                <svg class="accordion-icon" viewBox="0 0 24 24" aria-hidden="true">
+                    <path d="M6 9l6 6 6-6" fill="none" stroke="currentColor"
+                          stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                </svg>
+            </summary>
+
+            <div class="accordion-panel">
+
+                <p>
+                    Bibliografia, slides e materiais de leitura complementares
+                    serão listados aqui.
+                </p>
+
+            </div>
+
+        </details>
+
+        <details class="accordion" name="course-accordion" lang="pt-BR">
+
+            <summary class="accordion-summary">
+                <h2>Horário de atendimento</h2>
+                <svg class="accordion-icon" viewBox="0 0 24 24" aria-hidden="true">
+                    <path d="M6 9l6 6 6-6" fill="none" stroke="currentColor"
+                          stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                </svg>
+            </summary>
+
+            <div class="accordion-panel">
+
+                <p>
+                    O horário de atendimento (plantão de dúvidas) será informado
+                    aqui.
+                </p>
+
+            </div>
+
+        </details>
+
+        <details class="accordion" name="course-accordion" lang="pt-BR">
+
+            <summary class="accordion-summary">
+                <h2>Política de colaboração</h2>
+                <svg class="accordion-icon" viewBox="0 0 24 24" aria-hidden="true">
+                    <path d="M6 9l6 6 6-6" fill="none" stroke="currentColor"
+                          stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                </svg>
+            </summary>
+
+            <div class="accordion-panel">
+
+                <p>
+                    As regras sobre trabalho em grupo, uso de IA e o que é
+                    considerado plágio serão detalhadas aqui.
+                </p>
+
+            </div>
+
+        </details>
+
+        <details class="accordion" name="course-accordion" lang="pt-BR">
+
+            <summary class="accordion-summary">
+                <h2>Orientações para os trabalhos, provas e notas</h2>
+                <svg class="accordion-icon" viewBox="0 0 24 24" aria-hidden="true">
+                    <path d="M6 9l6 6 6-6" fill="none" stroke="currentColor"
+                          stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                </svg>
+            </summary>
+
+            <div class="accordion-panel">
+
+                <p>
+                    Os critérios de avaliação, pesos, formato das provas e a
+                    política de notas serão detalhados aqui.
+                </p>
+
+            </div>
+
+        </details>
+
+        <details class="accordion" name="course-accordion">
+
+            <summary class="accordion-summary">
+                <h2>Offerings</h2>
+                <svg class="accordion-icon" viewBox="0 0 24 24" aria-hidden="true">
+                    <path d="M6 9l6 6 6-6" fill="none" stroke="currentColor"
+                          stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                </svg>
+            </summary>
+
+            <div class="accordion-panel">
+
+                <div class="course-item">
+
+                    <ul>
+                        <!-- Add one entry per year/semester, e.g.:
+                        <li><a href="#">2026.1</a></li>
+                        -->
+                    </ul>
+
+                </div>
+
+            </div>
+
+        </details>
 
     </section>
 

--- a/pages/teaching/web-programming-2.html
+++ b/pages/teaching/web-programming-2.html
@@ -43,119 +43,223 @@
 
     </section>
 
-    <section lang="pt-BR">
-
-        <h2>Descrição da disciplina</h2>
-
-        <p>
-            Curso de continuidade focado em desenvolvimento web no lado do
-            servidor com Node.js e Express, cobrindo arquitetura MVC,
-            templating no servidor com EJS, construção de aplicações CRUD
-            e uma introdução a vulnerabilidades comuns de segurança web,
-            como injeção de SQL e gerenciamento de sessões.
-        </p>
-
-    </section>
-
-    <section lang="pt-BR">
-
-        <h2>Horários das aulas</h2>
-
-        <p>
-            Os horários específicos desta oferta serão informados aqui.
-        </p>
-
-    </section>
-
-    <section lang="pt-BR">
-
-        <h2>Equipe</h2>
-
-        <p>
-            Docentes, monitores e equipe de apoio desta disciplina serão
-            listados aqui.
-        </p>
-
-    </section>
-
-    <section lang="pt-BR">
-
-        <h2>Calendário do semestre</h2>
-
-        <p>
-            O calendário com aulas, avaliações e entregas será publicado
-            aqui a cada semestre.
-        </p>
-
-    </section>
-
-    <section lang="pt-BR">
-
-        <h2>Pré-requisitos</h2>
-
-        <p>
-            Os pré-requisitos desta disciplina serão informados aqui.
-        </p>
-
-    </section>
-
-    <section lang="pt-BR">
-
-        <h2>Material de leitura</h2>
-
-        <p>
-            Bibliografia, slides e materiais de leitura complementares
-            serão listados aqui.
-        </p>
-
-    </section>
-
-    <section lang="pt-BR">
-
-        <h2>Horário de atendimento</h2>
-
-        <p>
-            O horário de atendimento (plantão de dúvidas) será informado
-            aqui.
-        </p>
-
-    </section>
-
-    <section lang="pt-BR">
-
-        <h2>Política de colaboração</h2>
-
-        <p>
-            As regras sobre trabalho em grupo, uso de IA e o que é
-            considerado plágio serão detalhadas aqui.
-        </p>
-
-    </section>
-
-    <section lang="pt-BR">
-
-        <h2>Orientações para os trabalhos, provas e notas</h2>
-
-        <p>
-            Os critérios de avaliação, pesos, formato das provas e a
-            política de notas serão detalhados aqui.
-        </p>
-
-    </section>
-
     <section>
 
-        <h2>Offerings</h2>
+        <details class="accordion" name="course-accordion" lang="pt-BR">
 
-        <div class="course-item">
+            <summary class="accordion-summary">
+                <h2>Descrição da disciplina</h2>
+                <svg class="accordion-icon" viewBox="0 0 24 24" aria-hidden="true">
+                    <path d="M6 9l6 6 6-6" fill="none" stroke="currentColor"
+                          stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                </svg>
+            </summary>
 
-            <ul>
-                <!-- Add one entry per year/semester, e.g.:
-                <li><a href="#">2026.1</a></li>
-                -->
-            </ul>
+            <div class="accordion-panel">
 
-        </div>
+                <p>
+                    Curso de continuidade focado em desenvolvimento web no lado do
+                    servidor com Node.js e Express, cobrindo arquitetura MVC,
+                    templating no servidor com EJS, construção de aplicações CRUD
+                    e uma introdução a vulnerabilidades comuns de segurança web,
+                    como injeção de SQL e gerenciamento de sessões.
+                </p>
+
+            </div>
+
+        </details>
+
+        <details class="accordion" name="course-accordion" lang="pt-BR">
+
+            <summary class="accordion-summary">
+                <h2>Horários das aulas</h2>
+                <svg class="accordion-icon" viewBox="0 0 24 24" aria-hidden="true">
+                    <path d="M6 9l6 6 6-6" fill="none" stroke="currentColor"
+                          stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                </svg>
+            </summary>
+
+            <div class="accordion-panel">
+
+                <p>
+                    Os horários específicos desta oferta serão informados aqui.
+                </p>
+
+            </div>
+
+        </details>
+
+        <details class="accordion" name="course-accordion" lang="pt-BR">
+
+            <summary class="accordion-summary">
+                <h2>Equipe</h2>
+                <svg class="accordion-icon" viewBox="0 0 24 24" aria-hidden="true">
+                    <path d="M6 9l6 6 6-6" fill="none" stroke="currentColor"
+                          stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                </svg>
+            </summary>
+
+            <div class="accordion-panel">
+
+                <p>
+                    Docentes, monitores e equipe de apoio desta disciplina serão
+                    listados aqui.
+                </p>
+
+            </div>
+
+        </details>
+
+        <details class="accordion" name="course-accordion" lang="pt-BR">
+
+            <summary class="accordion-summary">
+                <h2>Calendário do semestre</h2>
+                <svg class="accordion-icon" viewBox="0 0 24 24" aria-hidden="true">
+                    <path d="M6 9l6 6 6-6" fill="none" stroke="currentColor"
+                          stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                </svg>
+            </summary>
+
+            <div class="accordion-panel">
+
+                <p>
+                    O calendário com aulas, avaliações e entregas será publicado
+                    aqui a cada semestre.
+                </p>
+
+            </div>
+
+        </details>
+
+        <details class="accordion" name="course-accordion" lang="pt-BR">
+
+            <summary class="accordion-summary">
+                <h2>Pré-requisitos</h2>
+                <svg class="accordion-icon" viewBox="0 0 24 24" aria-hidden="true">
+                    <path d="M6 9l6 6 6-6" fill="none" stroke="currentColor"
+                          stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                </svg>
+            </summary>
+
+            <div class="accordion-panel">
+
+                <p>
+                    Os pré-requisitos desta disciplina serão informados aqui.
+                </p>
+
+            </div>
+
+        </details>
+
+        <details class="accordion" name="course-accordion" lang="pt-BR">
+
+            <summary class="accordion-summary">
+                <h2>Material de leitura</h2>
+                <svg class="accordion-icon" viewBox="0 0 24 24" aria-hidden="true">
+                    <path d="M6 9l6 6 6-6" fill="none" stroke="currentColor"
+                          stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                </svg>
+            </summary>
+
+            <div class="accordion-panel">
+
+                <p>
+                    Bibliografia, slides e materiais de leitura complementares
+                    serão listados aqui.
+                </p>
+
+            </div>
+
+        </details>
+
+        <details class="accordion" name="course-accordion" lang="pt-BR">
+
+            <summary class="accordion-summary">
+                <h2>Horário de atendimento</h2>
+                <svg class="accordion-icon" viewBox="0 0 24 24" aria-hidden="true">
+                    <path d="M6 9l6 6 6-6" fill="none" stroke="currentColor"
+                          stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                </svg>
+            </summary>
+
+            <div class="accordion-panel">
+
+                <p>
+                    O horário de atendimento (plantão de dúvidas) será informado
+                    aqui.
+                </p>
+
+            </div>
+
+        </details>
+
+        <details class="accordion" name="course-accordion" lang="pt-BR">
+
+            <summary class="accordion-summary">
+                <h2>Política de colaboração</h2>
+                <svg class="accordion-icon" viewBox="0 0 24 24" aria-hidden="true">
+                    <path d="M6 9l6 6 6-6" fill="none" stroke="currentColor"
+                          stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                </svg>
+            </summary>
+
+            <div class="accordion-panel">
+
+                <p>
+                    As regras sobre trabalho em grupo, uso de IA e o que é
+                    considerado plágio serão detalhadas aqui.
+                </p>
+
+            </div>
+
+        </details>
+
+        <details class="accordion" name="course-accordion" lang="pt-BR">
+
+            <summary class="accordion-summary">
+                <h2>Orientações para os trabalhos, provas e notas</h2>
+                <svg class="accordion-icon" viewBox="0 0 24 24" aria-hidden="true">
+                    <path d="M6 9l6 6 6-6" fill="none" stroke="currentColor"
+                          stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                </svg>
+            </summary>
+
+            <div class="accordion-panel">
+
+                <p>
+                    Os critérios de avaliação, pesos, formato das provas e a
+                    política de notas serão detalhados aqui.
+                </p>
+
+            </div>
+
+        </details>
+
+        <details class="accordion" name="course-accordion">
+
+            <summary class="accordion-summary">
+                <h2>Offerings</h2>
+                <svg class="accordion-icon" viewBox="0 0 24 24" aria-hidden="true">
+                    <path d="M6 9l6 6 6-6" fill="none" stroke="currentColor"
+                          stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                </svg>
+            </summary>
+
+            <div class="accordion-panel">
+
+                <div class="course-item">
+
+                    <ul>
+                        <!-- Add one entry per year/semester, e.g.:
+                        <li><a href="#">2026.1</a></li>
+                        -->
+                    </ul>
+
+                </div>
+
+            </div>
+
+        </details>
 
     </section>
 


### PR DESCRIPTION
Wrap each syllabus section (description, schedule, team, calendar, prerequisites, reading material, office hours, collaboration policy, grading guidelines, and offerings) in a native <details>/<summary> accordion on each course page, collapsed by default and grouped so only one section is open at a time. The Teaching overview page is unaffected.